### PR TITLE
#26 선착순 쿠폰 발급

### DIFF
--- a/src/main/java/com/example/application/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/application/coupon/controller/CouponController.java
@@ -1,0 +1,36 @@
+package com.example.application.coupon.controller;
+
+import com.example.application.coupon.service.CouponService;
+import com.example.application.security.UserAccount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @GetMapping("/coupon")
+    public String couponForm() {
+        return "coupon-test";
+    }
+
+    @PostMapping("/coupon")
+    public String issueCoupon(@RequestParam String code, @AuthenticationPrincipal UserAccount userAccount) {
+
+        couponService.issueCouponToUser(code, userAccount);
+
+        return "redirect:/";
+    }
+
+
+
+}

--- a/src/main/java/com/example/application/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/example/application/coupon/mapper/CouponMapper.java
@@ -1,0 +1,4 @@
+package com.example.application.coupon.mapper;
+
+public interface CouponMapper {
+}

--- a/src/main/java/com/example/application/coupon/service/CouponService.java
+++ b/src/main/java/com/example/application/coupon/service/CouponService.java
@@ -1,0 +1,7 @@
+package com.example.application.coupon.service;
+
+import com.example.application.security.UserAccount;
+
+public interface CouponService {
+    void issueCouponToUser(String code, UserAccount userAccount);
+}

--- a/src/main/java/com/example/application/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/example/application/coupon/service/CouponServiceImpl.java
@@ -3,20 +3,46 @@ package com.example.application.coupon.service;
 import com.example.application.coupon.mapper.CouponMapper;
 import com.example.application.security.UserAccount;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CouponServiceImpl implements CouponService {
 
-    private final CouponMapper couponMapper;
+    private static final String COUPON_COUNT_KEY = "_coupon_count";
+    private static final long MAX_COUPON_COUNT = 10;
+    
+    
+  //  private final CouponMapper couponMapper;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public void issueCouponToUser(String code, UserAccount userAccount) {
         // 쿠폰 유효성 검증
+        // 쿠폰 code DB에 유효 한지 체크 하고 남은 수량 반환 받아서 동적으로 바꾸기 위해 MAX_COUPON_COUNT 를 지우고 변경
 
-        // 레디스 sorted set으로 대기열, 락
+        // 쿠폰 카운터를 1증가하고 반환받음
+        Long couponCount = incrementCouponCount(code);
 
-        //db 업데이트
+        // 현재 발급된 쿠폰 수 체크
+        if (couponCount != null && couponCount <= MAX_COUPON_COUNT) {
+            // DB 에서 쿠폰 발급
+
+            log.info("쿠폰 발급되었습니다.");
+        } else {
+            log.info("쿠폰 없습니다.");
+           return;
+        }
+    }
+
+    private Long incrementCouponCount(String code) {
+        ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
+        Long couponCount = valueOps.increment(code + COUPON_COUNT_KEY);
+        return couponCount;
     }
 }

--- a/src/main/java/com/example/application/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/example/application/coupon/service/CouponServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.application.coupon.service;
+
+import com.example.application.coupon.mapper.CouponMapper;
+import com.example.application.security.UserAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponServiceImpl implements CouponService {
+
+    private final CouponMapper couponMapper;
+
+    @Override
+    public void issueCouponToUser(String code, UserAccount userAccount) {
+        // 쿠폰 유효성 검증
+
+        // 레디스 sorted set으로 대기열, 락
+
+        //db 업데이트
+    }
+}

--- a/src/main/resources/create-tables.sql
+++ b/src/main/resources/create-tables.sql
@@ -116,5 +116,42 @@ CREATE TABLE login_failure (
    username VARCHAR(255) NOT NULL
 );
 
+
+
+
+
+
 ALTER table likes
 ADD column batch_status BOOLEAN DEFAULT FALSE
+
+CREATE TABLE coupon (
+coupon_id SERIAL PRIMARY KEY,
+coupon_code VARCHAR(255) NOT NULL,
+coupon_name VARCHAR(255) NOT NULL,
+quantity INT NOT NULL,
+expiration_date TIMESTAMP
+);
+
+COMMENT ON TABLE coupon IS '쿠폰';
+COMMENT ON COLUMN coupon.coupon_id IS '쿠폰 기본키(PK)';
+COMMENT ON COLUMN coupon.coupon_code IS '쿠폰 상수 코드';
+COMMENT ON COLUMN coupon.coupon_name IS '쿠폰 이름';
+COMMENT ON COLUMN coupon.quantity IS '쿠폰 수량';
+COMMENT ON COLUMN coupon.expiration_date IS '쿠폰 만료 날짜';
+
+
+
+CREATE TABLE coupon_usage (
+usage_id SERIAL PRIMARY KEY,
+coupon_id INT,
+user_id INT NOT NULL,
+used_date TIMESTAMP,
+is_used BOOLEAN DEFAULT FALSE
+);
+
+COMMENT ON TABLE coupon_usage IS '쿠폰 사용 정보';
+COMMENT ON COLUMN coupon_usage.usage_id IS '쿠폰 사용 기본키(PK)';
+COMMENT ON COLUMN coupon_usage.coupon_id IS '쿠폰 아이디(FK)';
+COMMENT ON COLUMN coupon_usage.user_id IS '사용자 아이디';
+COMMENT ON COLUMN coupon_usage.used_date IS '쿠폰 사용 날짜, 시간';
+COMMENT ON COLUMN coupon_usage.is_used IS '쿠폰 사용 여부';

--- a/src/main/resources/templates/coupon-test.html
+++ b/src/main/resources/templates/coupon-test.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head th:replace="fragments.html :: head"></head>
+<body>
+<nav th:replace="fragments.html :: nav"></nav>
+
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-2"></div>
+        <div class="col-8">
+            <p>쿠폰 테스트</p>
+            <form th:action="@{/coupon}" method="post">
+                <input hidden type="text" id="code" name="code" value="COUPON001">
+                <button type="submit">쿠폰 발행</button>
+            </form>
+        </div>
+        <div class="col-2"></div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -122,7 +122,7 @@
                     <a class="nav-link" th:href="@{/admin}" style="color: black; ">어드민</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="#" style="color: black;"></a>
+                    <a class="nav-link" th:href="@{/coupon}" style="color: black;">쿠폰 테스트</a>
                 </li>
             </ul>
         </div>

--- a/src/test/java/com/example/application/CouponServiceImplTest.java
+++ b/src/test/java/com/example/application/CouponServiceImplTest.java
@@ -1,0 +1,65 @@
+package com.example.application;
+
+import com.example.application.account.dto.Account;
+import com.example.application.coupon.service.CouponService;
+import com.example.application.coupon.service.CouponServiceImpl;
+import com.example.application.security.UserAccount;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class CouponServiceImplTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private CouponService couponService;
+
+
+    @Test
+    void testIssueCoupon() throws InterruptedException {
+        int threadCount = 100; // 원하는 스레드 수 설정
+        String testCode = "testCode";
+        UserAccount fakeUserAccount = mock(UserAccount.class);
+
+        // 스레드 풀 생성
+        ExecutorService executorService = Executors.newFixedThreadPool(30);
+
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            //병렬처리
+            executorService.submit(() -> {
+                try {
+                    couponService.issueCouponToUser(testCode, fakeUserAccount);
+                } finally {
+                    //스레드 모든작업 완료까지 대기
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+        redisTemplate.delete(testCode + "_coupon_count");
+    }
+
+}


### PR DESCRIPTION
incr 명령어를 활용해 쿠폰 발급 버튼을 누르면 카운트를 +1 시키고 정해진 수량을 초과하면 쿠폰을 발급하지 않도록 했다. 이 방식은 원자적인 incr을 사용해 카운터를 증가시켜서 여러 스레드가 동시에 접근하더라도 정확한 쿠폰 발급 개수를 유지할 수 있게 해준다고 한다. 테스트 결과 맞다.